### PR TITLE
Add base theme property because not defining it has been deprecated

### DIFF
--- a/themes/noscreenshot_2_theme/noscreenshot_2_theme.info.yml
+++ b/themes/noscreenshot_2_theme/noscreenshot_2_theme.info.yml
@@ -2,3 +2,4 @@ name: 'Another NoScreenshot theme'
 type: theme
 description: 'An another theme without a screenshot'
 core: 8.x
+base theme: stable

--- a/themes/noscreenshot_theme/noscreenshot_theme.info.yml
+++ b/themes/noscreenshot_theme/noscreenshot_theme.info.yml
@@ -2,3 +2,4 @@ name: 'NoScreenshot theme'
 type: theme
 description: 'A theme without a screenshot'
 core: 8.x
+base theme: stable


### PR DESCRIPTION
Not defining `base theme` property was deprecated here: https://www.drupal.org/project/drupal/issues/3065545. We should add it to the themes shipped as part of this module.